### PR TITLE
Included gas comparison modules for RoleBasedAccess Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,22 @@ Gas consumption evaluation of Ownable related operations provided by the tested 
 </details>
 
 <details>
+<summary>RoleBasedAccess</summary>
+
+Gas consumption evaluation of RoleBasedAccess contracts related operations provided by the tested libraries. By comparing gas usage, developers can make informed decisions about the most efficient library for this functionality.
+
+**Gas Usage Comparison**:
+
+| Function Name     | OpenZeppelin | Solady            | Solmate            | Gas Efficiency |
+|-------------------|---------------|------------------|--------------------|----------------|
+| owner             | 2363          | 2546             | 2444               | OpenZeppelin   |
+| grantRole         | 29178         | 26096            | 18915              | Solmate        |
+| revokeRole        | 7146          | 6323             | 18915              | Solady         |
+
+
+</details>
+
+<details>
 <summary>ECDSA</summary>
 
 Gas consumption evaluation of ECDSA related operations provided by the tested libraries. By comparing gas usage, developers can make informed decisions about the most efficient library for this functionalities.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ Gas consumption evaluation of Ownable related operations provided by the tested 
 
 Gas consumption evaluation of RoleBasedAccess contracts related operations provided by the tested libraries. By comparing gas usage, developers can make informed decisions about the most efficient library for this functionality.
 
+> Note: *In order to be specific, it uses the following contracts for comparisons:*
+> 1. **AccessControl.sol** from Openzeppelin
+> 2. **OwnableRoles** from Solady
+> 3. **RolesAuthority** from Solmate
+> 
 **Gas Usage Comparison**:
 
 | Function Name     | OpenZeppelin | Solady            | Solmate            | Gas Efficiency |

--- a/src/RoleBasedAccess/OZRoleAccess.sol
+++ b/src/RoleBasedAccess/OZRoleAccess.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "lib/openzeppelin-contracts/contracts/access/AccessControl.sol";
+
+contract OZRoleAccess is AccessControl {
+  /**
+    * @notice Constructor
+    */
+  constructor () { }
+}

--- a/src/RoleBasedAccess/OZRoleAccess.sol
+++ b/src/RoleBasedAccess/OZRoleAccess.sol
@@ -7,5 +7,7 @@ contract OZRoleAccess is AccessControl {
   /**
     * @notice Constructor
     */
-  constructor () { }
+  constructor () { 
+    _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+  }
 }

--- a/src/RoleBasedAccess/SoladyRoleAccess.sol
+++ b/src/RoleBasedAccess/SoladyRoleAccess.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "lib/solady/src/auth/OwnableRoles.sol";
+
+contract SoladyRoleAccess is OwnableRoles {
+  /**
+    * @notice Constructor
+    */
+  constructor () { }
+}

--- a/src/RoleBasedAccess/SoladyRoleAccess.sol
+++ b/src/RoleBasedAccess/SoladyRoleAccess.sol
@@ -7,5 +7,7 @@ contract SoladyRoleAccess is OwnableRoles {
   /**
     * @notice Constructor
     */
-  constructor () { }
+  constructor () {
+    _initializeOwner(msg.sender);
+  }
 }

--- a/src/RoleBasedAccess/SolmateRoleAccess.sol
+++ b/src/RoleBasedAccess/SolmateRoleAccess.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "lib/solmate/src/auth/authorities/RolesAuthority.sol";
+
+contract SolmateRoleAccess is RolesAuthority {
+  /**
+    * @notice Constructor
+    */
+  constructor (Authority _authority) RolesAuthority(msg.sender, _authority) { }
+}

--- a/test/RoleBasedAccess/OZRoleBaseAccess.t.sol
+++ b/test/RoleBasedAccess/OZRoleBaseAccess.t.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../../src/RoleBasedAccess/OZRoleAccess.sol";
+
+contract OZRoleBaseAccessTest is Test {
+  OZRoleAccess public roleBasedAccess;
+  bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+  bytes32 public constant FIRST_ROLE = keccak256("FIRST_ROLE");
+
+  function setUp() public {
+    roleBasedAccess = new OZRoleAccess();
+  }
+
+  function testGetRoleAdmin() public view{
+    roleBasedAccess.getRoleAdmin(DEFAULT_ADMIN_ROLE);
+  }
+
+  function testContractAddress() public view returns(address){
+    return address(this);
+  }
+
+  function testGrantRole() public {
+    roleBasedAccess.grantRole(FIRST_ROLE, address(0xbeef));
+  }
+
+  function testRevokeRole() public {
+    roleBasedAccess.revokeRole(FIRST_ROLE, address(0xbeef));
+  }
+}

--- a/test/RoleBasedAccess/SoladyRoleBaseAccess.t.sol
+++ b/test/RoleBasedAccess/SoladyRoleBaseAccess.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../../src/RoleBasedAccess/SoladyRoleAccess.sol";
+
+contract SoladyOwnableTest is Test {
+  SoladyRoleAccess public soladyRoleAccess;
+
+  function setUp() public {
+    soladyRoleAccess = new SoladyRoleAccess();
+  }
+
+  function testOwner() public view{
+    soladyRoleAccess.owner();
+  }
+
+  function testGrantRole() public {
+    soladyRoleAccess.grantRoles(address(1), 111111);
+  }
+
+  function testRevokeRole() public {
+    soladyRoleAccess.revokeRoles(address(1), 111111);
+  }
+}

--- a/test/RoleBasedAccess/SolmateRoleBaseAccess.t.sol
+++ b/test/RoleBasedAccess/SolmateRoleBaseAccess.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../../src/RoleBasedAccess/SolmateRoleAccess.sol";
+
+contract SolmateOwnableTest is Test {
+  SolmateRoleAccess public solmateRoleAccess;
+
+  function setUp() public {
+    solmateRoleAccess = new SolmateRoleAccess(Authority(address(0)));
+  }
+
+  function testOwner() public view{
+    solmateRoleAccess.owner();
+  }
+
+  function testGrantRole() public {
+    solmateRoleAccess.setUserRole(address(0xBEEF), 0, true);
+  }
+
+  function testRevokeRole() public {
+    solmateRoleAccess.setUserRole(address(0xBEEF), 0, false);
+  }
+}


### PR DESCRIPTION
This PR mainly include the following important changes:

- Calculates and compares the gas of specifically the **grantRole**, **revokeRole** and **getOwner()** functions from all 3 contracts, i.e., Openzeppelin, Solady and Solmate
- In order to be specific, it uses the following contracts for comparisons:

1. **AccessControl.sol** from Openzeppelin
2. **OwnableRoles.sol** from Solady
3. RolesAuthority.sol** from Solmate