### PR TITLE
Add gas comparison for ERC4626

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,24 @@ Gas consumption evaluation of ERC1155 token-related operations provided by the t
 <details>
 <summary>ERC4626</summary>
 
-TODO
+Gas consumption evaluation of ERC4626 vault-related operations provided by the tested libraries. By comparing gas usage, developers can make informed decisions about the most efficient library for ERC4626 functionality.
+
+**Gas Usage Comparison**:
+
+| Function Name   | OpenZeppelin | Solady | Solmate | Gas Efficiency |
+|-----------------|-----------|---------------|----------------|----------------|
+| balanceOf       | 756       | 705           | 707            | Solady |
+| convertToAssets | 1544      | 1286          | 361 - 1424     | Solmate if totalSupply is zero else Solady |
+| deposit         | 62699     | 60093         | 59628          | Solmate        |
+| mint            | 62802     | 60199         | 59652          | Solmate        |
+| name            | 2886      | 2840          | 2922           | Solady         |
+| previewDeposit  | 2119      | 1875          | 1972           | Solady         |
+| previewWithdraw | 1666      | 1396          | 1497           | Solady         |
+| redeem          | 24849     | 23901         | 23944          | Solady         |
+| symbol          | 3226      | 3195          | 3252           | Solady         |
+| totalAssets     | 1139      | 912           | 1133           | Solady         |
+| totalSupply     | 383       | 380           | 380            | Solmate/Solady | 
+| withdraw        | 25958     | 24792         | 23922          | Solmate        |
 
 </details>
 

--- a/src/ERC4626/OZERC4626.sol
+++ b/src/ERC4626/OZERC4626.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "lib/openzeppelin-contracts/contracts/token/ERC20/extensions/ERC4626.sol";
+
+contract OZERC4626 is ERC4626 {
+    
+    /**
+     * @notice Constructor
+     */
+    constructor () ERC4626("Test4626", "TEST4626") { 
+        _mint(msg.sender, 0);
+        _mint(msg.sender, 1);
+        _mint(msg.sender, 2);
+        _mint(msg.sender, 3);
+        _mint(msg.sender, 5);
+    }
+
+    /**
+     * @notice Returns the name of the token
+     */
+    function name() public pure override returns (string memory) {
+        return "Test";
+    }
+
+    /**
+     * @notice Returns the symbol of the token
+     */
+    function symbol() public pure override returns (string memory) {
+        return "TEST";
+    }
+
+
+    function tokenURI(uint256 tokenId) public view override returns (string memory) {
+        return "ipfs://...";
+    }
+
+    /**
+     * @notice Mint a token to the specified address
+     * @param _to Receiver address
+     * @param _tokenId Id of the token to mint
+     */
+    function mint(address _to, uint _tokenId) external {
+        _mint(_to, _tokenId);
+    }
+
+    /**
+     * @notice Safely mint a token to the specified address
+     * @param _to Receiver address
+     * @param _tokenId Id of the token to mint
+     */
+    function safeMint(address _to, uint _tokenId) external {
+        _safeMint(_to, _tokenId);
+    }
+
+    /**
+     * @notice Burn a token
+     * @param _tokenId Id of the token to burn
+     */
+    function burn(uint _tokenId) external {
+        _burn(_tokenId);
+    }
+
+    /// _baseURI override
+    function _baseURI() internal view override returns (string memory) {
+        return "ipfs://.../";
+    }
+}

--- a/src/ERC4626/OZERC4626.sol
+++ b/src/ERC4626/OZERC4626.sol
@@ -1,68 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "lib/openzeppelin-contracts/contracts/token/ERC20/extensions/ERC4626.sol";
+import {ERC4626, ERC20, IERC20} from "lib/openzeppelin-contracts/contracts/token/ERC20/extensions/ERC4626.sol";
 
 contract OZERC4626 is ERC4626 {
-    
-    /**
-     * @notice Constructor
-     */
-    constructor () ERC4626("Test4626", "TEST4626") { 
-        _mint(msg.sender, 0);
-        _mint(msg.sender, 1);
-        _mint(msg.sender, 2);
-        _mint(msg.sender, 3);
-        _mint(msg.sender, 5);
+
+    constructor (
+        address _underlying,
+        string memory _name,
+        string memory _symbol
+    ) ERC20(_name, _symbol) ERC4626(IERC20(_underlying)) {}
+
+    function mint(address account, uint256 amount) external {
+        _mint(account, amount);
     }
 
-    /**
-     * @notice Returns the name of the token
-     */
-    function name() public pure override returns (string memory) {
-        return "Test";
-    }
-
-    /**
-     * @notice Returns the symbol of the token
-     */
-    function symbol() public pure override returns (string memory) {
-        return "TEST";
-    }
-
-
-    function tokenURI(uint256 tokenId) public view override returns (string memory) {
-        return "ipfs://...";
-    }
-
-    /**
-     * @notice Mint a token to the specified address
-     * @param _to Receiver address
-     * @param _tokenId Id of the token to mint
-     */
-    function mint(address _to, uint _tokenId) external {
-        _mint(_to, _tokenId);
-    }
-
-    /**
-     * @notice Safely mint a token to the specified address
-     * @param _to Receiver address
-     * @param _tokenId Id of the token to mint
-     */
-    function safeMint(address _to, uint _tokenId) external {
-        _safeMint(_to, _tokenId);
-    }
-
-    /**
-     * @notice Burn a token
-     * @param _tokenId Id of the token to burn
-     */
-    function burn(uint _tokenId) external {
-        _burn(_tokenId);
-    }
-
-    /// _baseURI override
-    function _baseURI() internal view override returns (string memory) {
-        return "ipfs://.../";
+    function burn(address account, uint256 amount) external {
+        _burn(account, amount);
     }
 }

--- a/src/ERC4626/SoladyERC4626.sol
+++ b/src/ERC4626/SoladyERC4626.sol
@@ -1,68 +1,70 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "lib/solady/src/tokens/ERC4626.sol";
+import {ERC20, ERC4626} from "lib/solady/src/tokens/ERC4626.sol";
 
 contract SoladyRC4626 is ERC4626 {
-    
+    bool public immutable useVirtualShares;
+    uint8 public immutable decimalsOffset;
+
+    address internal immutable _underlying;
+    uint8 internal immutable _decimals;
+
+    string internal _name;
+    string internal _symbol;
+
     /**
      * @notice Constructor
      */
-    constructor () ERC4626("Test4626", "TEST4626") { 
-        _mint(msg.sender, 0);
-        _mint(msg.sender, 1);
-        _mint(msg.sender, 2);
-        _mint(msg.sender, 3);
-        _mint(msg.sender, 5);
+    constructor (
+        address underlying_,
+        string memory name_,
+        string memory symbol_,
+        bool useVirtualShares_,
+        uint8 decimalsOffset_
+    )  { 
+        _underlying = underlying_;
+        (bool success, uint8 result) = _tryGetAssetDecimals(underlying_);
+        _decimals = success ? result : _DEFAULT_DECIMALS_OFFSET;
+
+        _name = name_;
+        _symbol = symbol_;
+
+        useVirtualShares = useVirtualShares_;
+        decimalsOffset = decimalsOffset_;
+    }
+
+    /**
+     * @notice Returns the name of the underlying asset
+     */
+    function asset() public view virtual override returns (address) {
+        return _underlying;
     }
 
     /**
      * @notice Returns the name of the token
      */
-    function name() public pure override returns (string memory) {
-        return "Test";
+    function name() public view override returns (string memory) {
+        return _name;
     }
 
     /**
      * @notice Returns the symbol of the token
      */
-    function symbol() public pure override returns (string memory) {
-        return "TEST";
+    function symbol() public view override returns (string memory) {
+        return _symbol;
     }
 
-
-    function tokenURI(uint256 tokenId) public view override returns (string memory) {
-        return "ipfs://...";
+    function _useVirtualShares() internal view virtual override returns (bool) {
+        return useVirtualShares;
     }
 
-    /**
-     * @notice Mint a token to the specified address
-     * @param _to Receiver address
-     * @param _tokenId Id of the token to mint
-     */
-    function mint(address _to, uint _tokenId) external {
-        _mint(_to, _tokenId);
+    function _underlyingDecimals() internal view virtual override returns (uint8) {
+        return _decimals;
     }
 
-    /**
-     * @notice Safely mint a token to the specified address
-     * @param _to Receiver address
-     * @param _tokenId Id of the token to mint
-     */
-    function safeMint(address _to, uint _tokenId) external {
-        _safeMint(_to, _tokenId);
+    function _decimalsOffset() internal view virtual override returns (uint8) {
+        return decimalsOffset;
     }
-
-    /**
-     * @notice Burn a token
-     * @param _tokenId Id of the token to burn
-     */
-    function burn(uint _tokenId) external {
-        _burn(_tokenId);
-    }
-
-    /// _baseURI override
-    function _baseURI() internal view override returns (string memory) {
-        return "ipfs://.../";
-    }
+    
 }

--- a/src/ERC4626/SoladyERC4626.sol
+++ b/src/ERC4626/SoladyERC4626.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "lib/solady/src/tokens/ERC4626.sol";
+
+contract SoladyRC4626 is ERC4626 {
+    
+    /**
+     * @notice Constructor
+     */
+    constructor () ERC4626("Test4626", "TEST4626") { 
+        _mint(msg.sender, 0);
+        _mint(msg.sender, 1);
+        _mint(msg.sender, 2);
+        _mint(msg.sender, 3);
+        _mint(msg.sender, 5);
+    }
+
+    /**
+     * @notice Returns the name of the token
+     */
+    function name() public pure override returns (string memory) {
+        return "Test";
+    }
+
+    /**
+     * @notice Returns the symbol of the token
+     */
+    function symbol() public pure override returns (string memory) {
+        return "TEST";
+    }
+
+
+    function tokenURI(uint256 tokenId) public view override returns (string memory) {
+        return "ipfs://...";
+    }
+
+    /**
+     * @notice Mint a token to the specified address
+     * @param _to Receiver address
+     * @param _tokenId Id of the token to mint
+     */
+    function mint(address _to, uint _tokenId) external {
+        _mint(_to, _tokenId);
+    }
+
+    /**
+     * @notice Safely mint a token to the specified address
+     * @param _to Receiver address
+     * @param _tokenId Id of the token to mint
+     */
+    function safeMint(address _to, uint _tokenId) external {
+        _safeMint(_to, _tokenId);
+    }
+
+    /**
+     * @notice Burn a token
+     * @param _tokenId Id of the token to burn
+     */
+    function burn(uint _tokenId) external {
+        _burn(_tokenId);
+    }
+
+    /// _baseURI override
+    function _baseURI() internal view override returns (string memory) {
+        return "ipfs://.../";
+    }
+}

--- a/src/ERC4626/SoladyERC4626.sol
+++ b/src/ERC4626/SoladyERC4626.sol
@@ -3,10 +3,7 @@ pragma solidity ^0.8.20;
 
 import {ERC20, ERC4626} from "lib/solady/src/tokens/ERC4626.sol";
 
-contract SoladyRC4626 is ERC4626 {
-    bool public immutable useVirtualShares;
-    uint8 public immutable decimalsOffset;
-
+contract SoladyERC4626 is ERC4626 {
     address internal immutable _underlying;
     uint8 internal immutable _decimals;
 
@@ -19,9 +16,7 @@ contract SoladyRC4626 is ERC4626 {
     constructor (
         address underlying_,
         string memory name_,
-        string memory symbol_,
-        bool useVirtualShares_,
-        uint8 decimalsOffset_
+        string memory symbol_
     )  { 
         _underlying = underlying_;
         (bool success, uint8 result) = _tryGetAssetDecimals(underlying_);
@@ -29,9 +24,6 @@ contract SoladyRC4626 is ERC4626 {
 
         _name = name_;
         _symbol = symbol_;
-
-        useVirtualShares = useVirtualShares_;
-        decimalsOffset = decimalsOffset_;
     }
 
     /**
@@ -55,16 +47,8 @@ contract SoladyRC4626 is ERC4626 {
         return _symbol;
     }
 
-    function _useVirtualShares() internal view virtual override returns (bool) {
-        return useVirtualShares;
-    }
-
     function _underlyingDecimals() internal view virtual override returns (uint8) {
         return _decimals;
     }
 
-    function _decimalsOffset() internal view virtual override returns (uint8) {
-        return decimalsOffset;
-    }
-    
 }

--- a/src/ERC4626/SolmateERC4626.sol
+++ b/src/ERC4626/SolmateERC4626.sol
@@ -1,68 +1,24 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "lib/solady/src/mixins/ERC4626.sol";
+import {ERC4626} from "lib/solmate/src/mixins/ERC4626.sol";
+import {ERC20} from "lib/solmate/src/tokens/ERC20.sol";
 
 contract SolmateERC4626 is ERC4626 {
-    
+
     /**
      * @notice Constructor
      */
-    constructor () ERC4626("Test4626", "TEST4626") { 
-        _mint(msg.sender, 0);
-        _mint(msg.sender, 1);
-        _mint(msg.sender, 2);
-        _mint(msg.sender, 3);
-        _mint(msg.sender, 5);
+    constructor (
+        ERC20 asset_,
+        string memory name_,
+        string memory symbol_,
+        bool useVirtualShares_,
+        uint8 decimalsOffset_
+    ) ERC4626(asset_, name_, symbol_) { }
+
+    function totalAssets() public view override returns (uint256) {
+        return asset.balanceOf(address(this));
     }
 
-    /**
-     * @notice Returns the name of the token
-     */
-    function name() public pure override returns (string memory) {
-        return "Test";
-    }
-
-    /**
-     * @notice Returns the symbol of the token
-     */
-    function symbol() public pure override returns (string memory) {
-        return "TEST";
-    }
-
-
-    function tokenURI(uint256 tokenId) public view override returns (string memory) {
-        return "ipfs://...";
-    }
-
-    /**
-     * @notice Mint a token to the specified address
-     * @param _to Receiver address
-     * @param _tokenId Id of the token to mint
-     */
-    function mint(address _to, uint _tokenId) external {
-        _mint(_to, _tokenId);
-    }
-
-    /**
-     * @notice Safely mint a token to the specified address
-     * @param _to Receiver address
-     * @param _tokenId Id of the token to mint
-     */
-    function safeMint(address _to, uint _tokenId) external {
-        _safeMint(_to, _tokenId);
-    }
-
-    /**
-     * @notice Burn a token
-     * @param _tokenId Id of the token to burn
-     */
-    function burn(uint _tokenId) external {
-        _burn(_tokenId);
-    }
-
-    /// _baseURI override
-    function _baseURI() internal view override returns (string memory) {
-        return "ipfs://.../";
-    }
 }

--- a/src/ERC4626/SolmateERC4626.sol
+++ b/src/ERC4626/SolmateERC4626.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "lib/solady/src/mixins/ERC4626.sol";
+
+contract SolmateERC4626 is ERC4626 {
+    
+    /**
+     * @notice Constructor
+     */
+    constructor () ERC4626("Test4626", "TEST4626") { 
+        _mint(msg.sender, 0);
+        _mint(msg.sender, 1);
+        _mint(msg.sender, 2);
+        _mint(msg.sender, 3);
+        _mint(msg.sender, 5);
+    }
+
+    /**
+     * @notice Returns the name of the token
+     */
+    function name() public pure override returns (string memory) {
+        return "Test";
+    }
+
+    /**
+     * @notice Returns the symbol of the token
+     */
+    function symbol() public pure override returns (string memory) {
+        return "TEST";
+    }
+
+
+    function tokenURI(uint256 tokenId) public view override returns (string memory) {
+        return "ipfs://...";
+    }
+
+    /**
+     * @notice Mint a token to the specified address
+     * @param _to Receiver address
+     * @param _tokenId Id of the token to mint
+     */
+    function mint(address _to, uint _tokenId) external {
+        _mint(_to, _tokenId);
+    }
+
+    /**
+     * @notice Safely mint a token to the specified address
+     * @param _to Receiver address
+     * @param _tokenId Id of the token to mint
+     */
+    function safeMint(address _to, uint _tokenId) external {
+        _safeMint(_to, _tokenId);
+    }
+
+    /**
+     * @notice Burn a token
+     * @param _tokenId Id of the token to burn
+     */
+    function burn(uint _tokenId) external {
+        _burn(_tokenId);
+    }
+
+    /// _baseURI override
+    function _baseURI() internal view override returns (string memory) {
+        return "ipfs://.../";
+    }
+}

--- a/src/ERC4626/SolmateERC4626.sol
+++ b/src/ERC4626/SolmateERC4626.sol
@@ -12,9 +12,7 @@ contract SolmateERC4626 is ERC4626 {
     constructor (
         ERC20 asset_,
         string memory name_,
-        string memory symbol_,
-        bool useVirtualShares_,
-        uint8 decimalsOffset_
+        string memory symbol_
     ) ERC4626(asset_, name_, symbol_) { }
 
     function totalAssets() public view override returns (uint256) {

--- a/test/ERC4626/OZERC4626.t.sol
+++ b/test/ERC4626/OZERC4626.t.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import {OZERC4626} from "../../src/ERC4626/OZERC4626.sol";
+import {OZToken} from "../../src/ERC20/OZToken.sol";
+
+contract OZERC4626Test is Test {
+    OZToken public underlying;
+    OZERC4626 public vault;
+
+    function setUp() public{
+        underlying = new OZToken();
+        vault = new OZERC4626(address(underlying), "Test Vault", "TVLT");
+    }
+
+    function testMetadata() public {
+        assertEq(vault.name(), "Test Vault");
+        assertEq(vault.symbol(), "TVLT");
+     }
+
+    function testSingleDepositWithdraw(uint128 amount) public {
+        vm.assume(amount < 10000000000000);
+
+        uint256 aliceUnderlyingAmount = amount;
+
+        address alice = address(0xABCD);
+
+        underlying.transfer(alice, aliceUnderlyingAmount);
+
+        vm.prank(alice);
+        underlying.approve(address(vault), aliceUnderlyingAmount);
+        assertEq(underlying.allowance(alice, address(vault)), aliceUnderlyingAmount);
+
+        uint256 alicePreDepositBal = underlying.balanceOf(alice);
+
+        vm.prank(alice);
+        uint256 aliceShareAmount = vault.deposit(aliceUnderlyingAmount, alice);
+
+
+        // Expect exchange rate to be 1:1 on initial deposit.
+        assertEq(aliceUnderlyingAmount, aliceShareAmount);
+        assertEq(vault.previewWithdraw(aliceShareAmount), aliceUnderlyingAmount);
+        assertEq(vault.previewDeposit(aliceUnderlyingAmount), aliceShareAmount);
+        assertEq(vault.totalSupply(), aliceShareAmount);
+        assertEq(vault.totalAssets(), aliceUnderlyingAmount);
+        assertEq(vault.balanceOf(alice), aliceShareAmount);
+        assertEq(vault.convertToAssets(vault.balanceOf(alice)), aliceUnderlyingAmount);
+        assertEq(underlying.balanceOf(alice), alicePreDepositBal - aliceUnderlyingAmount);
+
+        vm.prank(alice);
+        vault.withdraw(aliceUnderlyingAmount, alice, alice);
+
+        assertEq(vault.totalAssets(), 0);
+        assertEq(vault.balanceOf(alice), 0);
+        assertEq(vault.convertToAssets(vault.balanceOf(alice)), 0);
+        assertEq(underlying.balanceOf(alice), alicePreDepositBal);
+    }
+
+    function testSingleMintRedeem(uint128 amount) public {
+        vm.assume(amount < 10000000000000);
+
+        uint256 aliceShareAmount = amount;
+
+        address alice = address(0xABCD);
+
+        underlying.transfer(alice, aliceShareAmount);
+
+
+        vm.prank(alice);
+        underlying.approve(address(vault), aliceShareAmount);
+        assertEq(underlying.allowance(alice, address(vault)), aliceShareAmount);
+
+        uint256 alicePreDepositBal = underlying.balanceOf(alice);
+
+        vm.prank(alice);
+        uint256 aliceUnderlyingAmount = vault.mint(aliceShareAmount, alice);
+
+        // Expect exchange rate to be 1:1 on initial mint.
+        assertEq(aliceShareAmount, aliceUnderlyingAmount);
+        assertEq(vault.previewWithdraw(aliceShareAmount), aliceUnderlyingAmount);
+        assertEq(vault.previewDeposit(aliceUnderlyingAmount), aliceShareAmount);
+        assertEq(vault.totalSupply(), aliceShareAmount);
+        assertEq(vault.totalAssets(), aliceUnderlyingAmount);
+        assertEq(vault.balanceOf(alice), aliceUnderlyingAmount);
+        assertEq(vault.convertToAssets(vault.balanceOf(alice)), aliceUnderlyingAmount);
+        assertEq(underlying.balanceOf(alice), alicePreDepositBal - aliceUnderlyingAmount);
+
+        vm.prank(alice);
+        vault.redeem(aliceShareAmount, alice, alice);
+
+        assertEq(vault.totalAssets(), 0);
+        assertEq(vault.balanceOf(alice), 0);
+        assertEq(vault.convertToAssets(vault.balanceOf(alice)), 0);
+        assertEq(underlying.balanceOf(alice), alicePreDepositBal);
+    }
+
+}

--- a/test/ERC4626/SoladyERC4626.t.sol
+++ b/test/ERC4626/SoladyERC4626.t.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import {SoladyERC4626} from "../../src/ERC4626/SoladyERC4626.sol";
+import {SoladyToken} from "../../src/ERC20/SoladyToken.sol";
+
+contract SoladyERC4626Test is Test {
+    SoladyToken public underlying;
+    SoladyERC4626 public vault;
+
+    function setUp() public{
+        underlying = new SoladyToken();
+        vault = new SoladyERC4626(address(underlying), "Test Vault", "TVLT");
+    }
+
+    function testMetadata() public {
+        assertEq(vault.name(), "Test Vault");
+        assertEq(vault.symbol(), "TVLT");
+     }
+
+    function testSingleDepositWithdraw(uint128 amount) public {
+        vm.assume(amount < 10000000000000);
+
+        uint256 aliceUnderlyingAmount = amount;
+
+        address alice = address(0xABCD);
+
+        underlying.transfer(alice, aliceUnderlyingAmount);
+
+        vm.prank(alice);
+        underlying.approve(address(vault), aliceUnderlyingAmount);
+        assertEq(underlying.allowance(alice, address(vault)), aliceUnderlyingAmount);
+
+        uint256 alicePreDepositBal = underlying.balanceOf(alice);
+
+        vm.prank(alice);
+        uint256 aliceShareAmount = vault.deposit(aliceUnderlyingAmount, alice);
+
+
+        // Expect exchange rate to be 1:1 on initial deposit.
+        assertEq(aliceUnderlyingAmount, aliceShareAmount);
+        assertEq(vault.previewWithdraw(aliceShareAmount), aliceUnderlyingAmount);
+        assertEq(vault.previewDeposit(aliceUnderlyingAmount), aliceShareAmount);
+        assertEq(vault.totalSupply(), aliceShareAmount);
+        assertEq(vault.totalAssets(), aliceUnderlyingAmount);
+        assertEq(vault.balanceOf(alice), aliceShareAmount);
+        assertEq(vault.convertToAssets(vault.balanceOf(alice)), aliceUnderlyingAmount);
+        assertEq(underlying.balanceOf(alice), alicePreDepositBal - aliceUnderlyingAmount);
+
+        vm.prank(alice);
+        vault.withdraw(aliceUnderlyingAmount, alice, alice);
+
+        assertEq(vault.totalAssets(), 0);
+        assertEq(vault.balanceOf(alice), 0);
+        assertEq(vault.convertToAssets(vault.balanceOf(alice)), 0);
+        assertEq(underlying.balanceOf(alice), alicePreDepositBal);
+    }
+
+    function testSingleMintRedeem(uint128 amount) public {
+        vm.assume(amount < 10000000000000);
+
+        uint256 aliceShareAmount = amount;
+
+        address alice = address(0xABCD);
+
+        underlying.transfer(alice, aliceShareAmount);
+
+
+        vm.prank(alice);
+        underlying.approve(address(vault), aliceShareAmount);
+        assertEq(underlying.allowance(alice, address(vault)), aliceShareAmount);
+
+        uint256 alicePreDepositBal = underlying.balanceOf(alice);
+
+        vm.prank(alice);
+        uint256 aliceUnderlyingAmount = vault.mint(aliceShareAmount, alice);
+
+        // Expect exchange rate to be 1:1 on initial mint.
+        assertEq(aliceShareAmount, aliceUnderlyingAmount);
+        assertEq(vault.previewWithdraw(aliceShareAmount), aliceUnderlyingAmount);
+        assertEq(vault.previewDeposit(aliceUnderlyingAmount), aliceShareAmount);
+        assertEq(vault.totalSupply(), aliceShareAmount);
+        assertEq(vault.totalAssets(), aliceUnderlyingAmount);
+        assertEq(vault.balanceOf(alice), aliceUnderlyingAmount);
+        assertEq(vault.convertToAssets(vault.balanceOf(alice)), aliceUnderlyingAmount);
+        assertEq(underlying.balanceOf(alice), alicePreDepositBal - aliceUnderlyingAmount);
+
+        vm.prank(alice);
+        vault.redeem(aliceShareAmount, alice, alice);
+
+        assertEq(vault.totalAssets(), 0);
+        assertEq(vault.balanceOf(alice), 0);
+        assertEq(vault.convertToAssets(vault.balanceOf(alice)), 0);
+        assertEq(underlying.balanceOf(alice), alicePreDepositBal);
+    }
+
+}

--- a/test/ERC4626/SolmateERC4626.t.sol
+++ b/test/ERC4626/SolmateERC4626.t.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import {SolmateERC4626} from "../../src/ERC4626/SolmateERC4626.sol";
+import {SolmateToken} from "../../src/ERC20/SolmateToken.sol";
+
+contract SolmateERC4626Test is Test {
+    SolmateToken public underlying;
+    SolmateERC4626 public vault;
+
+    function setUp() public{
+        underlying = new SolmateToken();
+        vault = new SolmateERC4626(underlying, "Test Vault", "TVLT");
+    }
+
+    function testMetadata() public {
+        assertEq(vault.name(), "Test Vault");
+        assertEq(vault.symbol(), "TVLT");
+     }
+
+    function testSingleDepositWithdraw(uint128 amount) public {
+        vm.assume(amount < 10000000000000);
+
+        uint256 aliceUnderlyingAmount = amount + 1;
+
+        address alice = address(0xABCD);
+
+        underlying.transfer(alice, aliceUnderlyingAmount);
+
+        vm.prank(alice);
+        underlying.approve(address(vault), aliceUnderlyingAmount);
+        assertEq(underlying.allowance(alice, address(vault)), aliceUnderlyingAmount);
+
+        uint256 alicePreDepositBal = underlying.balanceOf(alice);
+
+        vm.prank(alice);
+        uint256 aliceShareAmount = vault.deposit(aliceUnderlyingAmount, alice);
+
+
+        // Expect exchange rate to be 1:1 on initial deposit.
+        assertEq(aliceUnderlyingAmount, aliceShareAmount);
+        assertEq(vault.previewWithdraw(aliceShareAmount), aliceUnderlyingAmount);
+        assertEq(vault.previewDeposit(aliceUnderlyingAmount), aliceShareAmount);
+        assertEq(vault.totalSupply(), aliceShareAmount);
+        assertEq(vault.totalAssets(), aliceUnderlyingAmount);
+        assertEq(vault.balanceOf(alice), aliceShareAmount);
+        assertEq(vault.convertToAssets(vault.balanceOf(alice)), aliceUnderlyingAmount);
+        assertEq(underlying.balanceOf(alice), alicePreDepositBal - aliceUnderlyingAmount);
+
+        vm.prank(alice);
+        vault.withdraw(aliceUnderlyingAmount, alice, alice);
+
+        assertEq(vault.totalAssets(), 0);
+        assertEq(vault.balanceOf(alice), 0);
+        assertEq(vault.convertToAssets(vault.balanceOf(alice)), 0);
+        assertEq(underlying.balanceOf(alice), alicePreDepositBal);
+    }
+
+    function testSingleMintRedeem(uint128 amount) public {
+        vm.assume(amount < 10000000000000);
+
+        uint256 aliceShareAmount = amount + 1;
+
+        address alice = address(0xABCD);
+
+        underlying.transfer(alice, aliceShareAmount);
+
+
+        vm.prank(alice);
+        underlying.approve(address(vault), aliceShareAmount);
+        assertEq(underlying.allowance(alice, address(vault)), aliceShareAmount);
+
+        uint256 alicePreDepositBal = underlying.balanceOf(alice);
+
+        vm.prank(alice);
+        uint256 aliceUnderlyingAmount = vault.mint(aliceShareAmount, alice);
+
+        // Expect exchange rate to be 1:1 on initial mint.
+        assertEq(aliceShareAmount, aliceUnderlyingAmount);
+        assertEq(vault.previewWithdraw(aliceShareAmount), aliceUnderlyingAmount);
+        assertEq(vault.previewDeposit(aliceUnderlyingAmount), aliceShareAmount);
+        assertEq(vault.totalSupply(), aliceShareAmount);
+        assertEq(vault.totalAssets(), aliceUnderlyingAmount);
+        assertEq(vault.balanceOf(alice), aliceUnderlyingAmount);
+        assertEq(vault.convertToAssets(vault.balanceOf(alice)), aliceUnderlyingAmount);
+        assertEq(underlying.balanceOf(alice), alicePreDepositBal - aliceUnderlyingAmount);
+
+        vm.prank(alice);
+        vault.redeem(aliceShareAmount, alice, alice);
+
+        assertEq(vault.totalAssets(), 0);
+        assertEq(vault.balanceOf(alice), 0);
+        assertEq(vault.convertToAssets(vault.balanceOf(alice)), 0);
+        assertEq(underlying.balanceOf(alice), alicePreDepositBal);
+    }
+
+}


### PR DESCRIPTION
Added gas comparison for ERC4626 contract implementations by OZ, Solmate and Solady. Results are added to README table in the corresponding section. 